### PR TITLE
Update to prevent NameError if jupter is not installed

### DIFF
--- a/algorithmx/main.py
+++ b/algorithmx/main.py
@@ -6,6 +6,7 @@ try:
     HAS_JUPYTER = True
 except:
     HAS_JUPYTER = False
+    JupyterCanvas = None  # type: ignore
 
 
 def http_server(


### PR DESCRIPTION
An error appears when you try to use the library, and you do not have jupyter installed. 
The error that appears is:
    NameError: name 'JupyterCanvas' is not defined
By adding the if statement, we can prevent this.